### PR TITLE
feat(asana): add Asana tracker support and unit tests for pick.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Linear](https://img.shields.io/badge/Linear-supported-5E6AD2)](https://linear.app)
 [![GitHub Issues](https://img.shields.io/badge/GitHub_Issues-supported-333)](https://github.com)
 [![Jira](https://img.shields.io/badge/Jira-supported-0052CC)](https://www.atlassian.com/software/jira)
+[![Asana](https://img.shields.io/badge/Asana-supported-F06A6A)](https://asana.com)
 
 </div>
 
@@ -196,6 +197,7 @@ That's it. On first use, ticket-pilot asks which tracker you use, verifies it's 
 | **Linear** | `claude mcp add --transport http linear https://mcp.linear.app/mcp` |
 | **GitHub** | `brew install gh && gh auth login` |
 | **Jira** | Configure the [Atlassian MCP server](https://www.npmjs.com/package/@anthropic/mcp-atlassian) |
+| **Asana** | Set `ASANA_TOKEN` and `ASANA_WORKSPACE_ID` — see [Asana setup](#asana-setup) below |
 
 ---
 
@@ -228,15 +230,80 @@ Commit this file to share the config with your team, or add it to `.gitignore` f
 
 ## Supported Trackers
 
-|  | Linear | GitHub Issues | Jira |
-|--|--------|--------------|------|
-| Read tickets | Yes | Yes | Yes |
-| Create tickets | Yes | Yes | Yes |
-| Update status | Yes | Via PR | Yes |
-| Add comments | Yes | Yes | Yes |
-| Sprint/cycle view | Yes | Milestones | Yes |
-| Branch name from ticket | Yes | — | — |
-| Moderate issues | Yes | Yes | Yes |
+|  | Linear | GitHub Issues | Jira | Asana |
+|--|--------|--------------|------|-------|
+| Read tickets | Yes | Yes | Yes | Yes |
+| Create tickets | Yes | Yes | Yes | — |
+| Update status | Yes | Via PR | Yes | Yes |
+| Add comments | Yes | Yes | Yes | Yes (via stories) |
+| Sprint/cycle view | Yes | Milestones | Yes | Due-date sort |
+| Branch name from ticket | Yes | — | — | — |
+| Moderate issues | Yes | Yes | Yes | — |
+
+---
+
+## Asana Setup
+
+ticket-pilot supports Asana via its [REST API v1](https://developers.asana.com/docs/asana). Authentication uses a **Personal Access Token** — no OAuth setup required.
+
+### 1. Create a Personal Access Token
+
+1. Go to [https://app.asana.com/0/my-apps](https://app.asana.com/0/my-apps)
+2. Click **Create new token**
+3. Give it a name (e.g., `ticket-pilot`) and copy the token
+
+### 2. Find your Workspace ID
+
+```bash
+curl -s "https://app.asana.com/api/1.0/workspaces" \
+  -H "Authorization: Bearer YOUR_ASANA_TOKEN" | jq '.data[] | {gid, name}'
+```
+
+### 3. Set environment variables
+
+```bash
+export ASANA_TOKEN="your-personal-access-token"
+export ASANA_WORKSPACE_ID="your-workspace-gid"
+
+# Optional: scope list_tickets to a specific project
+export ASANA_PROJECT_ID="your-project-gid"
+```
+
+Add these to your shell profile (`.zshrc`, `.bashrc`, etc.) for persistence.
+
+### 4. Configure ticket-pilot
+
+Add to `.claude/ticket-pilot.json`:
+
+```json
+{
+  "tracker": "asana"
+}
+```
+
+Or run `/ticket-pilot:setup --tracker asana` and select **asana** when prompted.
+
+### 5. Use the tracker script directly (optional)
+
+```bash
+# Get a single task
+./scripts/trackers/asana.sh get_ticket 1234567890123456
+
+# List your open tasks
+./scripts/trackers/asana.sh list_tickets mine
+
+# List all open tasks in the workspace (up to 100)
+./scripts/trackers/asana.sh list_tickets all 100
+
+# Mark a task completed
+./scripts/trackers/asana.sh update_ticket_status 1234567890123456 completed
+```
+
+### Notes
+
+- **Sprints**: Asana doesn't have a native sprint concept. The `sprint` scope returns all incomplete tasks sorted by due date ascending.
+- **In-progress status**: Asana uses sections and custom fields for workflow states rather than a built-in "in progress" status. `update_ticket_status <gid> in_progress` adds a comment instead.
+- **Project scoping**: Set `ASANA_PROJECT_ID` to narrow results to a single project rather than the whole workspace.
 
 ---
 
@@ -260,6 +327,9 @@ ticket-pilot/
     moderator.md                   # Subagent: issue moderation
   scripts/
     detect-tracker.sh              # ID format detection
+    pick.sh                        # Interactive ticket picker
+    trackers/
+      asana.sh                     # Asana tracker provider (get/list/update)
 ```
 
 No TypeScript. No build step. No `node_modules`. Just Markdown files that tell Claude what to do.

--- a/scripts/pick.sh
+++ b/scripts/pick.sh
@@ -101,7 +101,7 @@ detect_tracker() {
   # 3. Interactive picker
   echo -e "${BOLD}Which tracker do you use?${NC}" >&2
   local choice
-  choice=$(gum choose "github" "linear" "jira" || true)
+  choice=$(gum choose "github" "linear" "jira" "asana" || true)
   if [[ -z "$choice" ]]; then
     echo -e "${RED}Cancelled.${NC}" >&2
     exit 0
@@ -243,6 +243,67 @@ fetch_jira() {
   echo "$response" | jq -r '.issues[] | "\(.key)\t\(.fields.summary)\t\(.fields.status.name)"'
 }
 
+# --- Asana ---
+fetch_asana() {
+  local scope="$1"
+
+  if [[ -z "${ASANA_TOKEN:-}" ]]; then
+    echo -e "${RED}Error:${NC} ASANA_TOKEN environment variable is required for Asana." >&2
+    echo -e "Create one at: ${CYAN}https://app.asana.com/0/my-apps${NC}" >&2
+    exit 1
+  fi
+
+  if [[ -z "${ASANA_WORKSPACE_ID:-}" ]]; then
+    echo -e "${RED}Error:${NC} ASANA_WORKSPACE_ID environment variable is required for Asana." >&2
+    echo -e "Find your workspace ID in the Asana URL or via the API: ${CYAN}https://app.asana.com/api/1.0/workspaces${NC}" >&2
+    exit 1
+  fi
+
+  local fields="name,assignee,completed,permalink_url"
+  local filter
+  case "$scope" in
+    mine)
+      # Fetch tasks assigned to current user in the workspace
+      local me_response me_id
+      me_response=$(curl -sf "https://app.asana.com/api/1.0/users/me" \
+        -H "Authorization: Bearer $ASANA_TOKEN" 2>/dev/null)
+      if [[ -z "$me_response" ]]; then
+        echo -e "${RED}Asana API error:${NC} Failed to fetch current user." >&2
+        exit 1
+      fi
+      me_id=$(echo "$me_response" | jq -r '.data.gid')
+      filter="assignee=${me_id}&completed_since=now"
+      ;;
+    all)
+      filter="completed_since=now"
+      ;;
+    sprint)
+      # Asana doesn't have native sprints; use incomplete tasks sorted by due date
+      filter="completed_since=now&sort_by=due_date"
+      ;;
+  esac
+
+  local response
+  response=$(curl -sf \
+    "https://app.asana.com/api/1.0/workspaces/${ASANA_WORKSPACE_ID}/tasks?${filter}&opt_fields=${fields}&limit=50" \
+    -H "Authorization: Bearer $ASANA_TOKEN" 2>/dev/null)
+
+  if [[ -z "$response" ]]; then
+    echo -e "${RED}Asana API error:${NC} Connection failed." >&2
+    exit 1
+  fi
+
+  local errors
+  errors=$(echo "$response" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+  if [[ -n "$errors" ]]; then
+    echo -e "${RED}Asana API error:${NC} $errors" >&2
+    exit 1
+  fi
+
+  echo "$response" | jq -r \
+    '.data[] | select(.completed == false) | "\(.gid)\t\(.name)\topen"'
+}
+
 # --- Display formatting ---
 format_tickets() {
   local term_width
@@ -297,6 +358,7 @@ main() {
     github)  raw_tickets=$(fetch_github "$SCOPE") ;;
     linear)  raw_tickets=$(fetch_linear "$SCOPE") ;;
     jira)    raw_tickets=$(fetch_jira "$SCOPE") ;;
+    asana)   raw_tickets=$(fetch_asana "$SCOPE") ;;
     *)
       echo -e "${RED}Error:${NC} Unknown tracker: $tracker"
       exit 1

--- a/scripts/trackers/asana.sh
+++ b/scripts/trackers/asana.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+# ticket-pilot — Asana tracker provider
+#
+# Implements the standard tracker API used by ticket-pilot skills:
+#   get_ticket <task_gid>
+#   list_tickets [mine|all|sprint] [limit]
+#   update_ticket_status <task_gid> <status>
+#
+# Required environment variables:
+#   ASANA_TOKEN          — Personal Access Token (https://app.asana.com/0/my-apps)
+#   ASANA_WORKSPACE_ID   — Workspace GID (https://app.asana.com/api/1.0/workspaces)
+#
+# Optional:
+#   ASANA_PROJECT_ID     — Narrow list_tickets to a specific project GID
+#
+# Dependencies: curl, jq (no other non-standard tools)
+#
+# Exit codes:
+#   0  success
+#   1  configuration or API error
+
+set -euo pipefail
+
+ASANA_API="https://app.asana.com/api/1.0"
+
+# ---------------------------------------------------------------------------
+# _asana_check_env — verify required env vars are set
+# ---------------------------------------------------------------------------
+_asana_check_env() {
+  local missing=()
+  [[ -z "${ASANA_TOKEN:-}" ]]        && missing+=("ASANA_TOKEN")
+  [[ -z "${ASANA_WORKSPACE_ID:-}" ]] && missing+=("ASANA_WORKSPACE_ID")
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "Error: missing Asana environment variable(s): ${missing[*]}" >&2
+    echo "Set them and retry." >&2
+    echo "" >&2
+    echo "  ASANA_TOKEN          — Personal Access Token" >&2
+    echo "                         Create at: https://app.asana.com/0/my-apps" >&2
+    echo "  ASANA_WORKSPACE_ID   — Workspace GID" >&2
+    echo "                         List at: https://app.asana.com/api/1.0/workspaces" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# _asana_request <path> [extra curl args...]
+# Makes an authenticated GET request to the Asana REST API.
+# Prints the raw JSON response on stdout.
+# ---------------------------------------------------------------------------
+_asana_request() {
+  local path="$1"
+  shift
+  local response
+  response=$(curl -sf "${ASANA_API}${path}" \
+    -H "Authorization: Bearer ${ASANA_TOKEN}" \
+    -H "Accept: application/json" \
+    "$@" 2>/dev/null) || {
+    echo "Error: Asana API request failed for path: ${path}" >&2
+    exit 1
+  }
+
+  # Surface API-level errors
+  local api_error
+  api_error=$(echo "$response" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+  if [[ -n "$api_error" ]]; then
+    echo "Error: Asana API error: $api_error" >&2
+    exit 1
+  fi
+
+  echo "$response"
+}
+
+# ---------------------------------------------------------------------------
+# get_ticket <task_gid>
+#
+# Fetches a single Asana task and prints a structured summary to stdout.
+# Output format (tab-separated fields, one per line):
+#   id      <gid>
+#   title   <name>
+#   status  <open|completed>
+#   url     <permalink_url>
+#   assignee <name or unassigned>
+#   due     <due_on or none>
+#   desc    <notes (first 500 chars)>
+# ---------------------------------------------------------------------------
+get_ticket() {
+  local task_gid="$1"
+  if [[ -z "$task_gid" ]]; then
+    echo "Usage: get_ticket <task_gid>" >&2
+    exit 1
+  fi
+
+  _asana_check_env
+
+  local fields="gid,name,completed,notes,permalink_url,assignee,due_on,custom_fields,memberships"
+  local response
+  response=$(_asana_request "/tasks/${task_gid}?opt_fields=${fields}")
+
+  local data
+  data=$(echo "$response" | jq '.data')
+
+  local status
+  status=$(echo "$data" | jq -r 'if .completed then "completed" else "open" end')
+  local assignee
+  assignee=$(echo "$data" | jq -r '.assignee.name // "unassigned"')
+  local due
+  due=$(echo "$data" | jq -r '.due_on // "none"')
+  local notes
+  notes=$(echo "$data" | jq -r '.notes // ""' | head -c 500)
+
+  echo "id	$(echo "$data" | jq -r '.gid')"
+  echo "title	$(echo "$data" | jq -r '.name')"
+  echo "status	${status}"
+  echo "url	$(echo "$data" | jq -r '.permalink_url // "https://app.asana.com"')"
+  echo "assignee	${assignee}"
+  echo "due	${due}"
+  echo "desc	${notes}"
+}
+
+# ---------------------------------------------------------------------------
+# list_tickets [scope] [limit]
+#
+# scope: mine (default) | all | sprint
+#   mine   — tasks assigned to the authenticated user
+#   all    — all incomplete tasks in the workspace (or project if ASANA_PROJECT_ID set)
+#   sprint — same as all, sorted by due date ascending (Asana has no native sprint concept)
+#
+# limit: max tasks to return (default 50)
+#
+# Output: tab-separated rows of: <gid> <name> <status>
+# ---------------------------------------------------------------------------
+list_tickets() {
+  local scope="${1:-mine}"
+  local limit="${2:-50}"
+
+  _asana_check_env
+
+  local fields="gid,name,completed,permalink_url,assignee"
+  local params="opt_fields=${fields}&limit=${limit}"
+
+  if [[ -n "${ASANA_PROJECT_ID:-}" ]]; then
+    # Scope to a project
+    local endpoint="/projects/${ASANA_PROJECT_ID}/tasks?${params}&completed_since=now"
+    if [[ "$scope" == "sprint" ]]; then
+      endpoint="${endpoint}&sort_by=due_date&sort_ascending=true"
+    fi
+    local response
+    response=$(_asana_request "$endpoint")
+    echo "$response" | jq -r \
+      '.data[] | select(.completed == false) | "\(.gid)\t\(.name)\topen"'
+    return
+  fi
+
+  case "$scope" in
+    mine)
+      # Get the current user's GID
+      local me_resp me_id
+      me_resp=$(_asana_request "/users/me?opt_fields=gid")
+      me_id=$(echo "$me_resp" | jq -r '.data.gid')
+
+      local response
+      response=$(_asana_request \
+        "/workspaces/${ASANA_WORKSPACE_ID}/tasks?${params}&completed_since=now&assignee=${me_id}")
+      echo "$response" | jq -r \
+        '.data[] | select(.completed == false) | "\(.gid)\t\(.name)\topen"'
+      ;;
+
+    all)
+      local response
+      response=$(_asana_request \
+        "/workspaces/${ASANA_WORKSPACE_ID}/tasks?${params}&completed_since=now")
+      echo "$response" | jq -r \
+        '.data[] | select(.completed == false) | "\(.gid)\t\(.name)\topen"'
+      ;;
+
+    sprint)
+      # Asana has no native sprints — return incomplete tasks sorted by due date
+      local response
+      response=$(_asana_request \
+        "/workspaces/${ASANA_WORKSPACE_ID}/tasks?${params}&completed_since=now&sort_by=due_date&sort_ascending=true")
+      echo "$response" | jq -r \
+        '.data[] | select(.completed == false) | "\(.gid)\t\(.name)\topen"'
+      ;;
+
+    *)
+      echo "Error: unknown scope '$scope'. Use: mine | all | sprint" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# update_ticket_status <task_gid> <status>
+#
+# status values:
+#   open        — mark task as incomplete
+#   completed   — mark task as complete
+#   in_progress — add a comment (Asana uses sections/custom fields for in-progress)
+#
+# Prints a confirmation message to stdout on success.
+# ---------------------------------------------------------------------------
+update_ticket_status() {
+  local task_gid="$1"
+  local status="$2"
+
+  if [[ -z "$task_gid" ]] || [[ -z "$status" ]]; then
+    echo "Usage: update_ticket_status <task_gid> <status>" >&2
+    echo "  status: open | completed | in_progress" >&2
+    exit 1
+  fi
+
+  _asana_check_env
+
+  case "$status" in
+    open)
+      curl -sf -X PUT "${ASANA_API}/tasks/${task_gid}" \
+        -H "Authorization: Bearer ${ASANA_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d '{"data":{"completed":false}}' >/dev/null 2>&1 || {
+        echo "Error: failed to update task ${task_gid}" >&2
+        exit 1
+      }
+      echo "Task ${task_gid} marked as open."
+      ;;
+
+    completed)
+      curl -sf -X PUT "${ASANA_API}/tasks/${task_gid}" \
+        -H "Authorization: Bearer ${ASANA_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d '{"data":{"completed":true}}' >/dev/null 2>&1 || {
+        echo "Error: failed to update task ${task_gid}" >&2
+        exit 1
+      }
+      echo "Task ${task_gid} marked as completed."
+      ;;
+
+    in_progress)
+      # Asana has no universal "in progress" state — we add a comment instead.
+      # For teams using custom fields or sections, extend this function accordingly.
+      local comment_payload
+      comment_payload=$(printf '{"data":{"text":"Status updated to: in progress"}}')
+      curl -sf -X POST "${ASANA_API}/tasks/${task_gid}/stories" \
+        -H "Authorization: Bearer ${ASANA_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "$comment_payload" >/dev/null 2>&1 || {
+        echo "Error: failed to add in_progress comment to task ${task_gid}" >&2
+        exit 1
+      }
+      echo "Task ${task_gid} commented as in_progress (Asana has no native in-progress state; use sections or custom fields for workflow states)."
+      ;;
+
+    *)
+      echo "Error: unknown status '$status'. Use: open | completed | in_progress" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint — allows using this script directly:
+#   ./asana.sh get_ticket <gid>
+#   ./asana.sh list_tickets [mine|all|sprint] [limit]
+#   ./asana.sh update_ticket_status <gid> <status>
+# ---------------------------------------------------------------------------
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [[ $# -eq 0 ]]; then
+    echo "Usage: asana.sh <command> [args]"
+    echo ""
+    echo "Commands:"
+    echo "  get_ticket <task_gid>"
+    echo "  list_tickets [mine|all|sprint] [limit]"
+    echo "  update_ticket_status <task_gid> <status>"
+    exit 0
+  fi
+  "$@"
+fi

--- a/tests/unit/pick.test.sh
+++ b/tests/unit/pick.test.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+# Unit tests for scripts/pick.sh — tracker detection and argument parsing.
+# Pattern mirrors scripts/test-detect-tracker.sh.
+#
+# Strategy: source pick.sh minus the final `main "$@"` line so we can call
+# individual functions directly without triggering the full interactive flow.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PICK="$REPO_ROOT/scripts/pick.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    ((PASS++))
+  else
+    echo "  FAIL: $desc"
+    echo "         expected : '$expected'"
+    echo "         got      : '$actual'"
+    ((FAIL++))
+  fi
+}
+
+assert_exit() {
+  local desc="$1" expected_exit="$2"
+  shift 2
+  actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [[ "$actual_exit" == "$expected_exit" ]]; then
+    echo "  PASS: $desc (exit $actual_exit)"
+    ((PASS++))
+  else
+    echo "  FAIL: $desc (expected exit $expected_exit, got $actual_exit)"
+    ((FAIL++))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# source_pick: source pick.sh functions without executing main.
+# We strip the last line (`main "$@"`) and also strip `set -euo pipefail`
+# so the test runner's error handling isn't affected.
+# ---------------------------------------------------------------------------
+PICK_FUNCTIONS="$(mktemp /tmp/pick_functions_XXXX.sh)"
+# Remove: set -euo pipefail, main "$@", and check_deps (interactive/dep checks)
+sed '/^set -euo pipefail/d; /^main "\$@"/d' "$PICK" > "$PICK_FUNCTIONS"
+# Append a no-op check_deps so tests don't fail on missing gum/claude
+echo 'check_deps() { :; }' >> "$PICK_FUNCTIONS"
+chmod +x "$PICK_FUNCTIONS"
+trap 'rm -f "$PICK_FUNCTIONS"' EXIT
+
+# ---------------------------------------------------------------------------
+echo "=== pick.sh tests ==="
+echo ""
+echo "--- detect_tracker: --tracker flag takes priority ---"
+# ---------------------------------------------------------------------------
+
+run_detect_flag() {
+  local tracker_value="$1"
+  (
+    source "$PICK_FUNCTIONS"
+    TRACKER="$tracker_value"
+    gum() { return 1; }
+    detect_tracker 2>/dev/null
+  )
+}
+
+assert_eq "--tracker github"  "github"  "$(run_detect_flag github)"
+assert_eq "--tracker linear"  "linear"  "$(run_detect_flag linear)"
+assert_eq "--tracker jira"    "jira"    "$(run_detect_flag jira)"
+assert_eq "--tracker asana"   "asana"   "$(run_detect_flag asana)"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- detect_tracker: config file detection ---"
+# ---------------------------------------------------------------------------
+
+run_detect_config() {
+  local tracker_value="$1"
+  local tmp_config
+  tmp_config="$(mktemp /tmp/ticket_pilot_XXXX.json)"
+  printf '{"tracker":"%s"}' "$tracker_value" > "$tmp_config"
+  result=$(
+    source "$PICK_FUNCTIONS"
+    TRACKER=""
+    find_config() { echo "$tmp_config"; }
+    gum() { return 1; }
+    detect_tracker 2>/dev/null
+  )
+  rm -f "$tmp_config"
+  echo "$result"
+}
+
+assert_eq "config: github" "github" "$(run_detect_config github)"
+assert_eq "config: linear" "linear" "$(run_detect_config linear)"
+assert_eq "config: jira"   "jira"   "$(run_detect_config jira)"
+assert_eq "config: asana"  "asana"  "$(run_detect_config asana)"
+
+# When config has empty tracker field, gum is called (returns empty → exits 0).
+# Note: detect_tracker calls `exit 0` in the Cancelled branch which terminates
+# the subshell before any subsequent echo runs, so we capture the exit code
+# of the subshell directly.
+run_detect_empty_config_exit() {
+  local tmp_config
+  tmp_config="$(mktemp /tmp/ticket_pilot_XXXX.json)"
+  echo '{"tracker":""}' > "$tmp_config"
+  (
+    source "$PICK_FUNCTIONS"
+    TRACKER=""
+    find_config() { echo "$tmp_config"; }
+    gum() { return 1; }
+    detect_tracker 2>/dev/null
+  )
+  local exit_code=$?
+  rm -f "$tmp_config"
+  echo "$exit_code"
+}
+assert_eq "empty tracker in config: falls through to gum, exits 0" \
+  "0" "$(run_detect_empty_config_exit)"
+
+# No config and gum unavailable → exits 0 (Cancelled)
+run_detect_no_config_exit() {
+  (
+    source "$PICK_FUNCTIONS"
+    TRACKER=""
+    find_config() { echo ""; }
+    gum() { return 1; }
+    detect_tracker 2>/dev/null
+  )
+  echo $?
+}
+assert_eq "no config, no gum: exits 0 (Cancelled)" \
+  "0" "$(run_detect_no_config_exit)"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- detect_tracker: gum interactive fallback ---"
+# ---------------------------------------------------------------------------
+
+run_detect_gum() {
+  local gum_choice="$1"
+  (
+    source "$PICK_FUNCTIONS"
+    TRACKER=""
+    find_config() { echo ""; }
+    gum() { echo "$gum_choice"; }
+    detect_tracker 2>/dev/null
+  )
+}
+
+assert_eq "gum picks github"  "github"  "$(run_detect_gum github)"
+assert_eq "gum picks linear"  "linear"  "$(run_detect_gum linear)"
+assert_eq "gum picks jira"    "jira"    "$(run_detect_gum jira)"
+assert_eq "gum picks asana"   "asana"   "$(run_detect_gum asana)"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- parse_args: ACTION and SCOPE ---"
+# ---------------------------------------------------------------------------
+
+run_parse() {
+  (
+    source "$PICK_FUNCTIONS"
+    parse_args "$@" 2>/dev/null
+    printf "ACTION=%s SCOPE=%s TRACKER=%s" "$ACTION" "$SCOPE" "$TRACKER"
+  )
+}
+
+assert_eq "no args: defaults" \
+  "ACTION= SCOPE=mine TRACKER=" \
+  "$(run_parse)"
+
+assert_eq "resolve action" \
+  "ACTION=resolve SCOPE=mine TRACKER=" \
+  "$(run_parse resolve)"
+
+assert_eq "explore action" \
+  "ACTION=explore SCOPE=mine TRACKER=" \
+  "$(run_parse explore)"
+
+assert_eq "triage action" \
+  "ACTION=triage SCOPE=mine TRACKER=" \
+  "$(run_parse triage)"
+
+assert_eq "moderate action" \
+  "ACTION=moderate SCOPE=mine TRACKER=" \
+  "$(run_parse moderate)"
+
+assert_eq "--all sets SCOPE=all" \
+  "ACTION= SCOPE=all TRACKER=" \
+  "$(run_parse --all)"
+
+assert_eq "--sprint sets SCOPE=sprint" \
+  "ACTION= SCOPE=sprint TRACKER=" \
+  "$(run_parse --sprint)"
+
+assert_eq "--tracker github" \
+  "ACTION= SCOPE=mine TRACKER=github" \
+  "$(run_parse --tracker github)"
+
+assert_eq "--tracker asana" \
+  "ACTION= SCOPE=mine TRACKER=asana" \
+  "$(run_parse --tracker asana)"
+
+assert_eq "resolve --all" \
+  "ACTION=resolve SCOPE=all TRACKER=" \
+  "$(run_parse resolve --all)"
+
+assert_eq "--tracker jira triage --sprint" \
+  "ACTION=triage SCOPE=sprint TRACKER=jira" \
+  "$(run_parse --tracker jira triage --sprint)"
+
+# flags can appear before action
+assert_eq "--all before action" \
+  "ACTION=resolve SCOPE=all TRACKER=" \
+  "$(run_parse --all resolve)"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- parse_args: unknown argument exits non-zero ---"
+# ---------------------------------------------------------------------------
+
+assert_exit "unknown arg --foo exits 1" "1" \
+  bash -c "source '$PICK_FUNCTIONS' 2>/dev/null; parse_args --foo 2>/dev/null"
+
+assert_exit "unknown action 'deploy' exits 1" "1" \
+  bash -c "source '$PICK_FUNCTIONS' 2>/dev/null; parse_args deploy 2>/dev/null"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- main: unknown tracker exits 1 ---"
+# ---------------------------------------------------------------------------
+
+unknown_tracker_exit() {
+  (
+    source "$PICK_FUNCTIONS"
+    detect_tracker() { echo "notexist"; }
+    fetch_github() { echo ""; }
+    main 2>/dev/null
+    echo $?
+  ) 2>/dev/null
+  # Capture the last exit code
+  local r=$?
+  echo $r
+}
+# main exits 1 when tracker is unknown
+(
+  source "$PICK_FUNCTIONS"
+  TRACKER="notexist"
+  detect_tracker() { echo "notexist"; }
+  main 2>/dev/null
+)
+exit_code=$?
+assert_eq "unknown tracker in main → exit 1" "1" "$exit_code"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- find_config: walks directory tree ---"
+# ---------------------------------------------------------------------------
+
+TMP_TREE="$(mktemp -d)"
+mkdir -p "$TMP_TREE/a/b/c"
+mkdir -p "$TMP_TREE/a/.claude"
+echo '{"tracker":"linear"}' > "$TMP_TREE/a/.claude/ticket-pilot.json"
+
+run_find_config() {
+  local start_dir="$1"
+  (
+    source "$PICK_FUNCTIONS"
+    cd "$start_dir"
+    find_config
+  )
+}
+
+assert_eq "find_config: finds config 2 levels up" \
+  "$TMP_TREE/a/.claude/ticket-pilot.json" \
+  "$(run_find_config "$TMP_TREE/a/b/c")"
+
+assert_eq "find_config: finds config in direct parent" \
+  "$TMP_TREE/a/.claude/ticket-pilot.json" \
+  "$(run_find_config "$TMP_TREE/a/b")"
+
+assert_eq "find_config: finds config in same dir" \
+  "$TMP_TREE/a/.claude/ticket-pilot.json" \
+  "$(run_find_config "$TMP_TREE/a")"
+
+# No config → returns empty
+TMP_EMPTY="$(mktemp -d)"
+assert_eq "find_config: returns empty when no config" \
+  "" \
+  "$(run_find_config "$TMP_EMPTY")"
+
+rm -rf "$TMP_TREE" "$TMP_EMPTY"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

This PR resolves two open issues:

### Issue #1 — Unit tests for pick.sh
Added `tests/unit/pick.test.sh` with **33 unit tests** covering:
- `detect_tracker()`: flag priority, config file reading (github/linear/jira/asana), gum interactive fallback, empty-config edge case
- `parse_args()`: all actions (resolve/explore/triage/moderate), `--all`/`--sprint` scopes, `--tracker` flag, mixed arg order, unknown args → exit 1
- `find_config()`: walks directory tree up to git root, returns empty when no config found
- `main()`: unknown tracker → exit 1

Pattern mirrors existing `scripts/test-detect-tracker.sh`. All 33 tests pass.

### Issue #2 — Asana tracker provider
- **`scripts/trackers/asana.sh`**: full tracker implementation
  - `get_ticket <gid>` — fetches a single task with id/title/status/url/assignee/due/description
  - `list_tickets [mine|all|sprint] [limit]` — lists incomplete tasks (scoped to workspace or project)
  - `update_ticket_status <gid> <status>` — marks open/completed/in_progress
  - Only deps: `curl` + `jq`
  - Usable as standalone CLI: `./scripts/trackers/asana.sh get_ticket 123`
- **`scripts/pick.sh`**: added Asana to gum chooser and `fetch_asana()` function
- **`README.md`**: Asana badge, full setup guide (token, workspace ID, env vars, config), updated tracker comparison table

## Test Plan
```bash
bash tests/unit/pick.test.sh      # 33 passed, 0 failed
bash scripts/test-detect-tracker.sh  # existing tests unaffected
```

Closes #1, Closes #2